### PR TITLE
feat: scope-aware caching with session_id callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Scope-aware caching with `session_id` callback in Ariadne adapter (Apollo-style)
+- Dual cache lookup: private key first (per-user), then public key (shared)
+- PUBLIC responses cached with shared key; PRIVATE responses cached per-user; PRIVATE without session_id skipped
+
+### Changed
+- `session_id` callback replaces `session_context_keys` for session identity (moved from config to adapter layer)
+- Strawberry extension now uses public-only caching (`context=None`) until scope support is added
+
+### Removed
+- `session_context_keys` field from `CacheConfig` (use `session_id` callback on `CachingGraphQL`/`CachingGraphQLHTTPHandler` instead)
+
 ## [0.0.1a2] - 2026-02-15
 
 ### Added

--- a/examples/fastapi-ariadne-redis/app/main.py
+++ b/examples/fastapi-ariadne-redis/app/main.py
@@ -30,7 +30,6 @@ cache_config = CacheConfig(
     key_prefix="example",
     cache_queries=True,
     cache_mutations=False,
-    session_context_keys=["current_user_id"],
 )
 
 cache_backend = RedisCacheBackend(
@@ -112,10 +111,15 @@ def should_cache(data: dict[str, Any]) -> bool:
     return "dbStats" not in query
 
 
+def get_session_id(context_value: dict) -> str | None:
+    return context_value.get("current_user_id")
+
+
 graphql_app = CachingGraphQL(
     schema,
     cache_service=cache_service,
     should_cache=should_cache,
+    session_id=get_session_id,
     debug=DEBUG,
     context_value=get_context_value,
     execute_get_queries=True,

--- a/src/cacheql/adapters/ariadne/graphql.py
+++ b/src/cacheql/adapters/ariadne/graphql.py
@@ -28,6 +28,7 @@ class CachingGraphQL(GraphQL):
         schema: Any,
         cache_service: CacheService,
         should_cache: Callable[[dict[str, Any]], bool] | None = None,
+        session_id: Callable[[Any], str | None] | None = None,
         set_http_headers: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -37,6 +38,7 @@ class CachingGraphQL(GraphQL):
             cache_service=cache_service,
             schema=schema,
             should_cache=should_cache,
+            session_id=session_id,
             set_http_headers=set_http_headers,
             debug=debug,
         )

--- a/src/cacheql/adapters/strawberry/extension.py
+++ b/src/cacheql/adapters/strawberry/extension.py
@@ -42,16 +42,6 @@ def CacheExtension(  # noqa: N802 - PascalCase intentional for class factory
         )
     """
 
-    def _extract_session_context(ctx: Any) -> dict[str, Any] | None:
-        keys = cache_service.config.session_context_keys
-        if not keys:
-            return None
-        context = getattr(ctx, "context", None)
-        if not isinstance(context, dict):
-            return None
-        extracted = {k: context[k] for k in keys if k in context}
-        return extracted or None
-
     class _CacheExtension(SchemaExtension):
         """Strawberry SchemaExtension for GraphQL response caching."""
 
@@ -122,12 +112,11 @@ def CacheExtension(  # noqa: N802 - PascalCase intentional for class factory
             if should_cache and not should_cache(ctx):
                 return
 
-            session_context = _extract_session_context(ctx)
             cached = await cache_service.get_cached_response(
                 operation_name=operation_name,
                 query=query,
                 variables=variables,
-                context=session_context,
+                context=None,
             )
 
             if cached is not None:
@@ -164,13 +153,12 @@ def CacheExtension(  # noqa: N802 - PascalCase intentional for class factory
             )
 
             data = result.data if hasattr(result, "data") else result
-            session_context = _extract_session_context(ctx)
             await cache_service.cache_response(
                 operation_name=operation_name,
                 query=query,
                 variables=variables,
                 response=data,
-                context=session_context,
+                context=None,
             )
 
         async def _handle_mutation_invalidation(self) -> None:

--- a/src/cacheql/core/entities/cache_config.py
+++ b/src/cacheql/core/entities/cache_config.py
@@ -36,9 +36,6 @@ class CacheConfig:
     # Invalidation
     auto_invalidate_on_mutation: bool = True
 
-    # Context-aware cache keys
-    session_context_keys: list[str] | None = None
-
     # Cache Control (Apollo-style) settings
     use_cache_control: bool = True
     default_max_age: int = 0  # Default maxAge in seconds (0 = no cache by default)

--- a/tests/unit/adapters/ariadne/test_handler.py
+++ b/tests/unit/adapters/ariadne/test_handler.py
@@ -1,78 +1,324 @@
-"""Unit tests for CachingGraphQLHTTPHandler._extract_session_context."""
+"""Unit tests for CachingGraphQLHTTPHandler."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 ariadne = pytest.importorskip("ariadne")
 
 from cacheql.adapters.ariadne.handler import CachingGraphQLHTTPHandler  # noqa: E402
-from cacheql.core.entities.cache_config import CacheConfig  # noqa: E402
+from cacheql.core.entities.cache_control import (  # noqa: E402
+    CacheScope,
+    ResponseCachePolicy,
+)
 
 
-def _make_handler(config: CacheConfig | None = None) -> CachingGraphQLHTTPHandler:
+def _make_handler(
+    session_id=None,
+    default_max_age: int = 300,
+) -> CachingGraphQLHTTPHandler:
     """Create a handler with a mock cache service."""
+    from cacheql.core.entities.cache_config import CacheConfig
+
     svc = MagicMock()
-    svc.config = config or CacheConfig()
+    svc.config = CacheConfig(default_max_age=default_max_age)
+    svc.get_cached_response = AsyncMock(return_value=None)
+    svc.cache_response = AsyncMock()
 
     handler = object.__new__(CachingGraphQLHTTPHandler)
     handler._cache_service = svc
+    handler._should_cache = None
+    handler._session_id = session_id
+    handler._set_http_headers = True
+    handler._debug = False
+    handler._schema_directives = None
+
+    # Mock calculator
+    handler._calculator = MagicMock()
+    handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+        max_age=300, scope=CacheScope.PUBLIC
+    )
+
     return handler
 
 
-class TestExtractSessionContext:
-    def test_returns_none_when_no_session_context_keys(self):
-        handler = _make_handler(CacheConfig(session_context_keys=None))
-        result = handler._extract_session_context({"current_user_id": "1"})
-        assert result is None
+class TestGetSessionId:
+    def test_callback_returns_value(self):
+        handler = _make_handler(session_id=lambda ctx: "user-42")
+        assert handler._get_session_id({"current_user_id": "42"}) == "user-42"
 
-    def test_returns_none_when_empty_session_context_keys(self):
-        handler = _make_handler(CacheConfig(session_context_keys=[]))
-        result = handler._extract_session_context({"current_user_id": "1"})
-        assert result is None
+    def test_callback_returns_none(self):
+        handler = _make_handler(session_id=lambda ctx: None)
+        assert handler._get_session_id({"current_user_id": "42"}) is None
 
-    def test_returns_none_when_context_is_not_dict(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id"])
-        )
-        result = handler._extract_session_context("not-a-dict")
-        assert result is None
+    def test_no_callback(self):
+        handler = _make_handler(session_id=None)
+        assert handler._get_session_id({"current_user_id": "42"}) is None
 
-    def test_returns_none_when_context_is_none(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id"])
-        )
-        result = handler._extract_session_context(None)
-        assert result is None
 
-    def test_extracts_configured_keys(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id"])
+class TestDualLookup:
+    @pytest.mark.asyncio
+    async def test_private_hit(self):
+        """When sid is set and private cache entry exists, return it."""
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        private_response = {"data": {"me": {"id": "1"}}}
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[private_response]
         )
-        result = handler._extract_session_context(
-            {"current_user_id": "42", "request": "obj"}
-        )
-        assert result == {"current_user_id": "42"}
 
-    def test_extracts_multiple_keys(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id", "tenant_id"])
-        )
-        result = handler._extract_session_context(
-            {"current_user_id": "42", "tenant_id": "t1", "extra": "ignored"}
-        )
-        assert result == {"current_user_id": "42", "tenant_id": "t1"}
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { me { id } }"}
 
-    def test_returns_none_when_no_configured_keys_found(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id"])
+        success, result = await handler.execute_graphql_query(
+            request, data, context_value={"current_user_id": "1"}
         )
-        result = handler._extract_session_context({"other_key": "value"})
-        assert result is None
 
-    def test_partial_match_returns_found_keys_only(self):
-        handler = _make_handler(
-            CacheConfig(session_context_keys=["current_user_id", "tenant_id"])
+        assert success is True
+        assert result == private_response
+        handler._cache_service.get_cached_response.assert_awaited_once_with(
+            operation_name=None,
+            query="query { me { id } }",
+            variables=None,
+            context={"session_id": "user-1"},
         )
-        result = handler._extract_session_context({"current_user_id": "42"})
-        assert result == {"current_user_id": "42"}
+
+    @pytest.mark.asyncio
+    async def test_public_hit_after_private_miss(self):
+        """When sid is set but private misses, try public key."""
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        public_response = {"data": {"users": [{"id": "1"}]}}
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[None, public_response]
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+
+        success, result = await handler.execute_graphql_query(
+            request, data, context_value={"current_user_id": "1"}
+        )
+
+        assert success is True
+        assert result == public_response
+        calls = handler._cache_service.get_cached_response.call_args_list
+        assert len(calls) == 2
+        # First call: private lookup
+        assert calls[0].kwargs["context"] == {"session_id": "user-1"}
+        # Second call: public lookup
+        assert calls[1].kwargs["context"] is None
+
+    @pytest.mark.asyncio
+    async def test_both_miss(self):
+        """When both private and public miss, execute query."""
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[None, None]
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+        executed_response = (True, {"data": {"users": []}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            success, result = await handler.execute_graphql_query(
+                request, data, context_value={"current_user_id": "1"}
+            )
+
+        assert success is True
+        assert handler._cache_service.get_cached_response.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_sid_skips_private_lookup(self):
+        """When no session_id callback, only public lookup is performed."""
+        handler = _make_handler(session_id=None)
+        public_response = {"data": {"users": [{"id": "1"}]}}
+        handler._cache_service.get_cached_response = AsyncMock(
+            return_value=public_response
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+
+        success, result = await handler.execute_graphql_query(
+            request, data, context_value={}
+        )
+
+        assert success is True
+        assert result == public_response
+        handler._cache_service.get_cached_response.assert_awaited_once_with(
+            operation_name=None,
+            query="query { users { id } }",
+            variables=None,
+            context=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_sid_callback_returns_none_skips_private_lookup(self):
+        """When session_id callback returns None, only public lookup."""
+        handler = _make_handler(session_id=lambda ctx: None)
+        public_response = {"data": {"users": [{"id": "1"}]}}
+        handler._cache_service.get_cached_response = AsyncMock(
+            return_value=public_response
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+
+        success, result = await handler.execute_graphql_query(
+            request, data, context_value={}
+        )
+
+        assert success is True
+        handler._cache_service.get_cached_response.assert_awaited_once_with(
+            operation_name=None,
+            query="query { users { id } }",
+            variables=None,
+            context=None,
+        )
+
+
+class TestScopeAwareStore:
+    @pytest.mark.asyncio
+    async def test_public_scope_stores_with_no_context(self):
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[None, None]
+        )
+        handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+            max_age=300, scope=CacheScope.PUBLIC
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+        executed_response = (True, {"data": {"users": []}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            await handler.execute_graphql_query(
+                request, data, context_value={"current_user_id": "1"}
+            )
+
+        handler._cache_service.cache_response.assert_awaited_once()
+        call_kwargs = handler._cache_service.cache_response.call_args.kwargs
+        assert call_kwargs["context"] is None
+
+    @pytest.mark.asyncio
+    async def test_private_scope_with_sid_stores_with_session_context(self):
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[None, None]
+        )
+        handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+            max_age=300, scope=CacheScope.PRIVATE
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { me { id } }"}
+        executed_response = (True, {"data": {"me": {"id": "1"}}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            await handler.execute_graphql_query(
+                request, data, context_value={"current_user_id": "1"}
+            )
+
+        handler._cache_service.cache_response.assert_awaited_once()
+        call_kwargs = handler._cache_service.cache_response.call_args.kwargs
+        assert call_kwargs["context"] == {"session_id": "user-1"}
+
+    @pytest.mark.asyncio
+    async def test_private_scope_without_sid_skips_cache(self):
+        handler = _make_handler(session_id=None)
+        handler._cache_service.get_cached_response = AsyncMock(return_value=None)
+        handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+            max_age=300, scope=CacheScope.PRIVATE
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { me { id } }"}
+        executed_response = (True, {"data": {"me": {"id": "1"}}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            await handler.execute_graphql_query(
+                request, data, context_value={}
+            )
+
+        handler._cache_service.cache_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_private_scope_with_sid_callback_returning_none_skips_cache(self):
+        handler = _make_handler(session_id=lambda ctx: None)
+        handler._cache_service.get_cached_response = AsyncMock(return_value=None)
+        handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+            max_age=300, scope=CacheScope.PRIVATE
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { me { id } }"}
+        executed_response = (True, {"data": {"me": {"id": "1"}}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            await handler.execute_graphql_query(
+                request, data, context_value={}
+            )
+
+        handler._cache_service.cache_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_cacheable_skips_store(self):
+        handler = _make_handler(session_id=lambda ctx: "user-1")
+        handler._cache_service.get_cached_response = AsyncMock(
+            side_effect=[None, None]
+        )
+        handler._calculator.calculate_policy.return_value = ResponseCachePolicy(
+            max_age=0, scope=CacheScope.PUBLIC
+        )
+
+        request = MagicMock()
+        request.state = MagicMock()
+        data = {"query": "query { users { id } }"}
+        executed_response = (True, {"data": {"users": []}})
+
+        with patch.object(
+            CachingGraphQLHTTPHandler.__bases__[0],
+            "execute_graphql_query",
+            new_callable=AsyncMock,
+            return_value=executed_response,
+        ):
+            await handler.execute_graphql_query(
+                request, data, context_value={}
+            )
+
+        handler._cache_service.cache_response.assert_not_called()

--- a/tests/unit/adapters/strawberry/test_extension.py
+++ b/tests/unit/adapters/strawberry/test_extension.py
@@ -595,9 +595,8 @@ class TestOnOperation:
             mock_check.assert_awaited_once()
             mock_cache.assert_awaited_once()
 
-    async def test_check_cache_passes_session_context(self):
-        config = CacheConfig(session_context_keys=["current_user_id"])
-        svc = _make_cache_service(config=config)
+    async def test_always_passes_none_context_on_check(self):
+        svc = _make_cache_service()
         ctx = _make_context(context={"current_user_id": "42"})
         ext = _make_ext(svc, ctx)
 
@@ -607,12 +606,11 @@ class TestOnOperation:
             operation_name="GetUser",
             query=ctx.query,
             variables={"id": "1"},
-            context={"current_user_id": "42"},
+            context=None,
         )
 
-    async def test_cache_response_passes_session_context(self):
-        config = CacheConfig(session_context_keys=["current_user_id"])
-        svc = _make_cache_service(config=config)
+    async def test_always_passes_none_context_on_store(self):
+        svc = _make_cache_service()
         result = MagicMock()
         result.errors = None
         result.data = {"user": {"id": "1"}}
@@ -632,51 +630,6 @@ class TestOnOperation:
             query="query GetUser { user { id } }",
             variables={"id": "1"},
             response={"user": {"id": "1"}},
-            context={"current_user_id": "42"},
-        )
-
-    async def test_no_session_context_keys_passes_none(self):
-        svc = _make_cache_service()  # default config has no session_context_keys
-        ctx = _make_context(context={"current_user_id": "42"})
-        ext = _make_ext(svc, ctx)
-
-        await ext._check_cache()
-
-        svc.get_cached_response.assert_awaited_once_with(
-            operation_name="GetUser",
-            query=ctx.query,
-            variables={"id": "1"},
-            context=None,
-        )
-
-    async def test_context_not_dict_passes_none(self):
-        config = CacheConfig(session_context_keys=["current_user_id"])
-        svc = _make_cache_service(config=config)
-        ctx = _make_context()
-        ctx.context = "not-a-dict"
-        ext = _make_ext(svc, ctx)
-
-        await ext._check_cache()
-
-        svc.get_cached_response.assert_awaited_once_with(
-            operation_name="GetUser",
-            query=ctx.query,
-            variables={"id": "1"},
-            context=None,
-        )
-
-    async def test_no_matching_keys_passes_none(self):
-        config = CacheConfig(session_context_keys=["current_user_id"])
-        svc = _make_cache_service(config=config)
-        ctx = _make_context(context={"other_key": "value"})
-        ext = _make_ext(svc, ctx)
-
-        await ext._check_cache()
-
-        svc.get_cached_response.assert_awaited_once_with(
-            operation_name="GetUser",
-            query=ctx.query,
-            variables={"id": "1"},
             context=None,
         )
 


### PR DESCRIPTION
## Summary

- Replace `session_context_keys` (CacheConfig field) with a `session_id` callback on the Ariadne adapter, following Apollo Server's scope-aware caching model
- Implement dual cache lookup: private key first (per-user), then public key (shared), so PUBLIC queries are never needlessly cached per-user
- PRIVATE responses without a `session_id` are skipped (not cached), with a warning logged
- Simplify Strawberry extension to public-only caching (`context=None`) until scope calculation is added

## Test plan

- [x] `TestGetSessionId` — callback returns value, returns None, no callback
- [x] `TestDualLookup` — private hit, public hit after private miss, both miss, no sid skips private
- [x] `TestScopeAwareStore` — PUBLIC stores with `context=None`, PRIVATE+sid stores with session context, PRIVATE without sid skips, not cacheable skips
- [x] `TestScopeAwareCaching` (integration) — private per-user isolation, public shared across users
- [x] Strawberry tests updated to assert `context=None` uniformly
- [x] All 233 tests passing, mypy clean, ruff clean on changed files